### PR TITLE
Allow dot and slash as message identifier

### DIFF
--- a/src/influxdb-cpp-rest/input_sanitizer.cpp
+++ b/src/influxdb-cpp-rest/input_sanitizer.cpp
@@ -12,7 +12,7 @@
 
 namespace influxdb {
     namespace utility {
-        constexpr const char* regex = R"((^[a-zA-Z0-9_\-]+$|"(?:[^\\"]|\\.)+"))";
+        constexpr const char* regex = R"((^[a-zA-Z0-9_/\\.\-]+$|"(?:[^\\"]|\\.)+"))";
 
         const std::regex check_identifier(regex);
 


### PR DESCRIPTION
line protocol can include '/' and '.' without double quotes. (confirmed on influxdb 1.7.6)